### PR TITLE
API Key is now optional.

### DIFF
--- a/Source/OCGoogleDirectionsAPI.xcodeproj/xcshareddata/xcschemes/OCGoogleDirectionsAPITests.xcscheme
+++ b/Source/OCGoogleDirectionsAPI.xcodeproj/xcshareddata/xcschemes/OCGoogleDirectionsAPITests.xcscheme
@@ -5,6 +5,19 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES"
+            buildForTesting = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "27C6E8C118C6578B0035B80F"
+               BuildableName = "OCGoogleDirectionsAPITests.xctest"
+               BlueprintName = "OCGoogleDirectionsAPITests"
+               ReferencedContainer = "container:OCGoogleDirectionsAPI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"

--- a/Source/OCGoogleDirectionsAPI/Client/OCDirectionsAPIClient.m
+++ b/Source/OCGoogleDirectionsAPI/Client/OCDirectionsAPIClient.m
@@ -21,10 +21,6 @@ static NSString *_defaultKey;
 
 - (instancetype)init
 {
-    if (_defaultKey == nil) {
-        [NSException raise:NSInternalInconsistencyException format:@"The Directions API key has not been provided."];
-    }
-    
     return [self initWithKey:_defaultKey];
 }
 

--- a/Source/OCGoogleDirectionsAPI/Client/RequestURLCreator/OCDirectionsRequestURLCreatorJSON.m
+++ b/Source/OCGoogleDirectionsAPI/Client/RequestURLCreator/OCDirectionsRequestURLCreatorJSON.m
@@ -33,8 +33,7 @@ static NSString *const kOCGoogleDirectionsRequestAttributeSeparator = @"|";
 - (NSString *)stringFromRequest:(OCDirectionsRequest *)request useHttps:(BOOL)useHttps andKey:(NSString *)key
 {
 	OCAssertParameterNotNil(request, @"Request is nil.");
-    OCAssertParameterNotNil(key, @"Key is nil.");
-	
+
     NSMutableString *string = [self baseStringWithHttps:useHttps];
     
     [self appendOrigin:request toString:string];
@@ -45,8 +44,10 @@ static NSString *const kOCGoogleDirectionsRequestAttributeSeparator = @"|";
     [self appendRestrictions:request toString:string];
     [self appendRegion:request toString:string];
     [self appendAlternatives:request toString:string];
-    [self appendKey:key toString:string];
-    
+    if(key != nil) {
+        [self appendKey:key toString:string];
+    }
+
     NSString *stringEncoded = [string stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     return stringEncoded;
 }
@@ -54,8 +55,7 @@ static NSString *const kOCGoogleDirectionsRequestAttributeSeparator = @"|";
 - (NSURL *)urlFromRequest:(OCDirectionsRequest *)request useHttps:(BOOL)useHttps andKey:(NSString *)key
 {
 	OCAssertParameterNotNil(request, @"Request is nil.");
-    OCAssertParameterNotNil(key, @"Key is nil.");
-	
+
     NSString *requestString = [self stringFromRequest:request useHttps:useHttps andKey:key];
     NSURL *url = [[NSURL alloc] initWithString:requestString];
     return url;

--- a/Source/OCGoogleDirectionsAPI/Request/OCDirectionsRequest.m
+++ b/Source/OCGoogleDirectionsAPI/Request/OCDirectionsRequest.m
@@ -82,6 +82,14 @@
     return self;
 }
 
+- (OCDirectionsRequestValidator *)requestValidator
+{
+    if (_requestValidator == nil) {
+        self.requestValidator = [OCDirectionsRequestValidator new];
+    }
+    return _requestValidator;
+}
+
 @end
 
 @implementation OCDirectionsRequest (Creation)
@@ -147,14 +155,6 @@
 {
     BOOL isValid = [self.requestValidator isValid:self];
     return isValid;
-}
-
-- (OCDirectionsRequestValidator *)requestValidator
-{
-    if (_requestValidator == nil) {
-        self.requestValidator = [OCDirectionsRequestValidator new];
-    }
-    return _requestValidator;
 }
 
 @end


### PR DESCRIPTION
I've made the api-key optional. When there is a api-key present you are limited to 2500 request per day per api-key. When you don't have any api-key you are limited to 2500 requests per ip address.